### PR TITLE
Prevent NaN from displaying by checking for falsy value

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,8 +10,10 @@ export default class App extends React.Component {
   };
 
   setOneRM = (reps, weight) => {
+    // prevent NaN from displaying by checking for falsy value
+    const oneRMInteger = Math.round(weight * (1 + reps / 30)) || 0;
     this.setState({
-      oneRM: Math.round(weight * (1 + reps / 30))
+      oneRM: oneRMInteger
     });
   };
 


### PR DESCRIPTION
before: 
<img width="372" alt="screen shot 2018-10-26 at 23 56 15" src="https://user-images.githubusercontent.com/5950956/47599876-161def00-d97d-11e8-9915-b670f76b172a.png">

after, with falsy check for NaN display: 
<img width="377" alt="screen shot 2018-10-27 at 00 04 41" src="https://user-images.githubusercontent.com/5950956/47599879-20d88400-d97d-11e8-9fbd-e26f8af711d2.png">

* wanted to check this project out after hearing about it on Syntax pod